### PR TITLE
Added SuperSelect and Grabbed URL of SavedObject with Type "Dashboard"

### DIFF
--- a/src/core/public/saved_objects/saved_objects_client.ts
+++ b/src/core/public/saved_objects/saved_objects_client.ts
@@ -491,7 +491,7 @@ export class SavedObjectsClient {
     return new SimpleSavedObject(this, options);
   }
 
-  private getPath(path: Array<string | undefined>): string {
+  public getPath(path: Array<string | undefined>): string {
     return resolveUrl(API_BASE_URL, join(...path));
   }
 

--- a/src/core/public/saved_objects/simple_saved_object.ts
+++ b/src/core/public/saved_objects/simple_saved_object.ts
@@ -31,7 +31,7 @@
 import { set } from '@elastic/safer-lodash-set';
 import { get, has } from 'lodash';
 import { SavedObject as SavedObjectType } from '../../server';
-import { SavedObjectsClientContract } from './saved_objects_client';
+import { SavedObjectsClient } from './saved_objects_client';
 
 /**
  * This class is a very simple wrapper for SavedObjects loaded from the server
@@ -54,7 +54,7 @@ export class SimpleSavedObject<T = unknown> {
   public updated_at: SavedObjectType<T>['updated_at'];
 
   constructor(
-    private client: SavedObjectsClientContract,
+    private client: SavedObjectsClient,
     {
       id,
       type,

--- a/src/plugins/vis_type_drilldown/opensearch_dashboards.json
+++ b/src/plugins/vis_type_drilldown/opensearch_dashboards.json
@@ -13,6 +13,5 @@
     "data",
     "visDefaultEditor"
   ],
-  "optionalPlugins": [],
-  "requiredBundles": ["opensearchDashboardsUtils", "opensearchDashboardsReact", "home"]
+  "optionalPlugins": []
 }

--- a/src/plugins/vis_type_drilldown/opensearch_dashboards.json
+++ b/src/plugins/vis_type_drilldown/opensearch_dashboards.json
@@ -13,5 +13,6 @@
     "data",
     "visDefaultEditor"
   ],
-  "optionalPlugins": []
+  "optionalPlugins": [],
+  "requiredBundles": ["opensearchDashboardsUtils", "opensearchDashboardsReact", "home"]
 }

--- a/src/plugins/vis_type_drilldown/public/drilldown_options.tsx
+++ b/src/plugins/vis_type_drilldown/public/drilldown_options.tsx
@@ -31,7 +31,7 @@ function DrilldownOptions({ stateParams, setValue }: VisOptionsProps<DrilldownVi
   } = useOpenSearchDashboards<DrilldownServices>();
 
   useEffect(() => {
-    const savedObject = savedObjectsClient.find({
+    const saved = savedObjectsClient.find({
       type: 'dashboard',
     });
   });

--- a/src/plugins/vis_type_drilldown/public/drilldown_options.tsx
+++ b/src/plugins/vis_type_drilldown/public/drilldown_options.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, Fragment, useState, useEffect } from 'react';
 import {
   EuiPanel,
   EuiTitle,
@@ -12,11 +12,13 @@ import {
   EuiFlexItem,
   EuiFieldText,
   EuiAccordion,
+  EuiSuperSelect,
+  EuiText,
 } from '@elastic/eui';
-import { FormattedMessage } from '@osd/i18n/react';
 
 import { VisOptionsProps } from 'src/plugins/vis_default_editor/public';
-import { DrilldownVisParams } from './types';
+import { useOpenSearchDashboards } from 'src/plugins/opensearch_dashboards_react/public';
+import { DrilldownServices, DrilldownVisParams } from './types';
 
 function DrilldownOptions({ stateParams, setValue }: VisOptionsProps<DrilldownVisParams>) {
   const onMarkdownUpdate = useCallback(
@@ -24,10 +26,57 @@ function DrilldownOptions({ stateParams, setValue }: VisOptionsProps<DrilldownVi
     [setValue]
   );
 
+  const {
+    services: { savedObjectsClient },
+  } = useOpenSearchDashboards<DrilldownServices>();
+
+  useEffect(() => {
+    const savedObject = savedObjectsClient.find({
+      type: 'dashboard',
+    });
+  });
+
   const onDescriptionUpdate = useCallback(
     (value: DrilldownVisParams['cardDescription']) => setValue('cardDescription', value),
     [setValue]
   );
+
+  const activeVisName = '';
+  const handleVisTypeChange = () => {};
+  const options = [
+    {
+      value: '1',
+      inputDisplay: 'Option 1',
+      dropdownDisplay: (
+        <Fragment>
+          <strong>Name</strong>
+          <EuiText size="s" color="subdued">
+            <p className="euiTextColor--subdued">
+              id
+              <br />
+              text
+            </p>
+          </EuiText>
+        </Fragment>
+      ),
+    },
+    {
+      value: '2',
+      inputDisplay: 'Option 2',
+      dropdownDisplay: (
+        <Fragment>
+          <strong>Name</strong>
+          <EuiText size="s" color="subdued">
+            <p className="euiTextColor--subdued">
+              id
+              <br />
+              text
+            </p>
+          </EuiText>
+        </Fragment>
+      ),
+    },
+  ];
 
   return (
     <EuiAccordion buttonContent="Drilldown 1">
@@ -70,6 +119,22 @@ function DrilldownOptions({ stateParams, setValue }: VisOptionsProps<DrilldownVi
               data-test-subj="markdownTextarea"
             />
           </EuiFlexItem>
+
+          <EuiFlexItem>
+            <EuiTitle size="xs">
+              <h2>
+                <label htmlFor="drilldownVisInput">Select a Destination</label>
+              </h2>
+            </EuiTitle>
+          </EuiFlexItem>
+
+          <EuiSuperSelect
+            options={options}
+            valueOfSelected={activeVisName}
+            onChange={handleVisTypeChange}
+            fullWidth
+            data-test-subj="chartPicker"
+          />
         </EuiFlexGroup>
       </EuiPanel>
     </EuiAccordion>

--- a/src/plugins/vis_type_drilldown/public/drilldown_options.tsx
+++ b/src/plugins/vis_type_drilldown/public/drilldown_options.tsx
@@ -17,7 +17,7 @@ import {
 } from '@elastic/eui';
 
 import { VisOptionsProps } from 'src/plugins/vis_default_editor/public';
-import { useOpenSearchDashboards } from 'src/plugins/opensearch_dashboards_react/public';
+import { useOpenSearchDashboards } from '../../opensearch_dashboards_react/public';
 import { DrilldownServices, DrilldownVisParams } from './types';
 
 function DrilldownOptions({ stateParams, setValue }: VisOptionsProps<DrilldownVisParams>) {
@@ -27,14 +27,24 @@ function DrilldownOptions({ stateParams, setValue }: VisOptionsProps<DrilldownVi
   );
 
   const {
-    services: { savedObjectsClient },
+    services: { http, savedObjects },
   } = useOpenSearchDashboards<DrilldownServices>();
 
+  let saved;
+
   useEffect(() => {
-    const saved = savedObjectsClient.find({
-      type: 'dashboard',
-    });
-  });
+    const fetchData = async () => {
+      saved = savedObjects?.client.find({
+        type: 'dashboard',
+
+      });
+      const path = (await saved).savedObjects[0]['client'].getPath(['dashboard', (await saved).savedObjects[0].id]).substring(28,);
+      console.log(path);
+      console.log(http.basePath.prepend('/app/dashboards#/view/'+ path));
+      console.log((await saved).savedObjects[0])
+    };
+    fetchData()
+  }, []);
 
   const onDescriptionUpdate = useCallback(
     (value: DrilldownVisParams['cardDescription']) => setValue('cardDescription', value),

--- a/src/plugins/vis_type_drilldown/public/types.ts
+++ b/src/plugins/vis_type_drilldown/public/types.ts
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { SavedObjectsClientContract } from 'src/core/public/saved_objects/saved_objects_client';
+import { CoreStart } from 'src/core/server';
 import { NavigationPublicPluginStart } from '../../navigation/public';
 import { VisualizationsSetup } from '../../visualizations/public';
-import { Arguments } from '../../vis_type_markdown/public/types';
 
 export interface VisDrilldownPluginSetup {
   getGreeting: () => string;
@@ -38,4 +39,8 @@ export interface DrilldownArguments {
 export interface DrilldownVisParams {
   cardName: DrilldownArguments['cardName'];
   cardDescription: DrilldownArguments['cardDescription'];
+}
+
+export interface DrilldownServices extends CoreStart {
+  savedObjectsClient: SavedObjectsClientContract;
 }


### PR DESCRIPTION
### Description

Added a select dropdown in the Drilldown Options form. 
Used useOpensearchDashboards to grab the http basepath and savedObject path. Prepended the basepath to the savedObject path to get the complete URL stored in savedObjectURL

### Issues Resolved

#2 

## Screenshot

<img width="1035" alt="Screen Shot 2023-11-29 at 11 06 43 AM" src="https://github.com/Willie-The-Lord/OpenSearch-Dashboards/assets/76860974/f1202a9e-12b3-4de9-8386-7836f5a53e5e">
Console logged test savedObject URL

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
